### PR TITLE
Removed support for .Net Framework 4.6

### DIFF
--- a/src/NLight.Tests.Benchmarks/IO/Text/DelimitedRecordReaderBenchmarks.cs
+++ b/src/NLight.Tests.Benchmarks/IO/Text/DelimitedRecordReaderBenchmarks.cs
@@ -7,6 +7,8 @@ using System.Text.RegularExpressions;
 using DS = DataStreams.Csv;
 using LW = LumenWorks.Framework.IO.Csv;
 using CH = CsvHelper;
+using System.Collections.Generic;
+using System;
 
 namespace NLight.Tests.Benchmarks.IO.Text
 {
@@ -106,7 +108,7 @@ namespace NLight.Tests.Benchmarks.IO.Text
 
 		public static void ReadAll_CsvHelper(DelimitedRecordReaderBenchmarkArguments args)
 		{
-			var config = new CH.Configuration.Configuration
+			var config = new CH.Configuration.CsvConfiguration(System.Globalization.CultureInfo.InvariantCulture)
 			{
 				BufferSize = args.BufferSize,
 				AllowComments = true,
@@ -124,9 +126,11 @@ namespace NLight.Tests.Benchmarks.IO.Text
 				{
 					while (reader.Read())
 					{
-						var record = reader.Context.Record;
-						for (int i = 0; i < record.Length; i++)
-							s = record[i];
+						IDictionary<string,Object> record = (IDictionary<string, Object>)reader.GetRecord<dynamic>();
+						foreach (var str in record.Values)
+						{
+							s = (string)str;
+						}
 					}
 				}
 				else

--- a/src/NLight.Tests.Benchmarks/IO/Text/DelimitedRecordReaderBenchmarks.cs
+++ b/src/NLight.Tests.Benchmarks/IO/Text/DelimitedRecordReaderBenchmarks.cs
@@ -126,11 +126,8 @@ namespace NLight.Tests.Benchmarks.IO.Text
 				{
 					while (reader.Read())
 					{
-						IDictionary<string,Object> record = (IDictionary<string, Object>)reader.GetRecord<dynamic>();
-						foreach (var str in record.Values)
-						{
-							s = (string)str;
-						}
+						for (int i = 0; i < reader.ColumnCount; i++)
+							s = reader[i];
 					}
 				}
 				else

--- a/src/NLight.Tests.Benchmarks/NLight.Tests.Benchmarks.csproj
+++ b/src/NLight.Tests.Benchmarks/NLight.Tests.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="6.1.1" />
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="LumenWorks.Framework.IO" Version="3.8.0" />
   </ItemGroup>
 

--- a/src/NLight.Tests.Unit/NLight.Tests.Unit.csproj
+++ b/src/NLight.Tests.Unit/NLight.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLight/NLight.csproj
+++ b/src/NLight/NLight.csproj
@@ -9,7 +9,7 @@
     <Description>Toolbox for .NET projects</Description>
     <PackageProjectUrl>https://github.com/slorion/nlight</PackageProjectUrl>
     <PackageTags>io,parser,csv,delimited,transaction,reactive,tree</PackageTags>
-    <PackageReleaseNotes>Increased compatibility to newer .net versions. Minimum supported .NET Version is 4.7.2 (.NET Standard 2.0)</PackageReleaseNotes>
+    <PackageReleaseNotes>Increased compatibility with newer .NET versions. Updated Reactive dependency to 5.0. NLight targets .NET Standard 2.0 (.NET Framework 4.6.1+, .NET Core 2.0+).</PackageReleaseNotes>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>C:\projects\oss\nlight\src\NLight.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/NLight/NLight.csproj
+++ b/src/NLight/NLight.csproj
@@ -9,9 +9,9 @@
     <Description>Toolbox for .NET projects</Description>
     <PackageProjectUrl>https://github.com/slorion/nlight</PackageProjectUrl>
     <PackageTags>io,parser,csv,delimited,transaction,reactive,tree</PackageTags>
-    <PackageReleaseNotes>Increased compatibility to newer .net versions. Removed support for .NET 4.6</PackageReleaseNotes>
-    <!--<SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>C:\projects\oss\nlight\src\NLight.snk</AssemblyOriginatorKeyFile>-->
+    <PackageReleaseNotes>Increased compatibility to newer .net versions. Minimum supported .NET Version is 4.7.2 (.NET Standard 2.0)</PackageReleaseNotes>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>C:\projects\oss\nlight\src\NLight.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NeutralLanguage>en</NeutralLanguage>
     <RepositoryUrl></RepositoryUrl>

--- a/src/NLight/NLight.csproj
+++ b/src/NLight/NLight.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
-    <Version>2.1.1</Version>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Version>2.2.0</Version>
     <Copyright>Copyright (c) 2009 Sébastien Lorion</Copyright>
     <Authors>Sébastien Lorion</Authors>
     <Company />
     <Description>Toolbox for .NET projects</Description>
     <PackageProjectUrl>https://github.com/slorion/nlight</PackageProjectUrl>
     <PackageTags>io,parser,csv,delimited,transaction,reactive,tree</PackageTags>
-    <PackageReleaseNotes>Added multi-targeting support for .NET 4.6</PackageReleaseNotes>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>C:\projects\oss\nlight\src\NLight.snk</AssemblyOriginatorKeyFile>
+    <PackageReleaseNotes>Increased compatibility to newer .net versions. Removed support for .NET 4.6</PackageReleaseNotes>
+    <!--<SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>C:\projects\oss\nlight\src\NLight.snk</AssemblyOriginatorKeyFile>-->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NeutralLanguage>en</NeutralLanguage>
     <RepositoryUrl></RepositoryUrl>
-    <FileVersion>2.1.1.0</FileVersion>
-    <AssemblyVersion>2.1.1.0</AssemblyVersion>
+    <FileVersion>2.2.0.0</FileVersion>
+    <AssemblyVersion>2.2.0.0</AssemblyVersion>
     <PackageLicenseUrl>https://github.com/slorion/nlight/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
 
@@ -37,8 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
-    <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
+    <PackageReference Include="System.Reactive.Core" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed support for .Net Framework 4.6
Upgraded test & benchmark projekt to .net 6.0
Upgraded NuGet packages. Updated CsvHelper benchmark code to the new CsvHelper version
(These changes fixed package downgrade warnings and publish issues with a newer .net 6.0 / EF. Core 7.0 application)